### PR TITLE
fix comment escape bug

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -25,7 +25,7 @@ layout: default
         {% include read-time.html %} read
       </p>
     </div>
-    <!-- <div class="visible-tablet">
+    <div class="visible-tablet">
       <br class="hidden-phone">
       <h1>{{ page.title }}</h1>
       <p class="metadata">
@@ -45,7 +45,7 @@ layout: default
       {% include read-time.html %} read
     </p>
     {% if page.image %}<img src="{{ page.image }}" alt="{{ page.title }}" />{% endif %}
-    {% endif %} -->
+    {% endif %}
 </header>
 <section id="main">
   {% include toggle-theme.html class="hidden-tablet" %}


### PR DESCRIPTION
## while I was deploying this web app,I notice a minor bug below:
![image](https://user-images.githubusercontent.com/44530292/113501770-57f1ed00-955a-11eb-9a96-5befb951f77b.png)
### 
So I managed to slove it,and find this piece of code in "post.html":
```
    <!-- <div class="visible-tablet">
      <br class="hidden-phone">
      <h1>{{ page.title }}</h1>
      <p class="metadata">
	<h1>{{ page.title }}</h1>
      {% include read-time.html %} read
    </p>
    {% if page.image %}<img src="{{ page.image }}" alt="{{ page.title }}" />{% endif %}
    {% endif %} -->
```
> ### there is a single <if> tag before this piece of code without matched <endif> tag,so the template complier would match that <endif> tag with the <if> tag in posted code above,therefore the comment mark didn't take effect actually.
> ### if a post has only image property without feather image,"-->" would appear in header,resulting in this bug,the it appear in your deployed site,too(in https://melody.dev/first-website/ ).I remove the comment mark and it now work well.
